### PR TITLE
Make QueueConfigurer aware of DLX so dependency can be established

### DIFF
--- a/sparkplug/config/queue.py
+++ b/sparkplug/config/queue.py
@@ -45,6 +45,12 @@ class QueueConfigurer(DependencyConfigurer):
         convert(create_args, 'arguments', parse_dict)
         self.create_args = create_args
 
+        dlx = create_args \
+            .get('arguments', {}) \
+            .get('x-dead-letter-exchange', None)
+        if dlx:
+            self.depends_on(dlx)
+
     def start(self, channel):
         _log.debug("Declaring queue %s (%r)", self.queue, self.create_args)
 

--- a/sparkplug/test/test_config/test_queue.py
+++ b/sparkplug/test/test_config/test_queue.py
@@ -1,6 +1,8 @@
 from nose.tools import eq_
 from mock import Mock, call
 from sparkplug.config.queue import QueueConfigurer
+from sparkplug.config.exchange import ExchangeConfigurer
+from sparkplug.config import calculate_dependencies
 
 
 def test_queue_configurer_arguments_not_passed():
@@ -21,3 +23,20 @@ def test_queue_configurer_takes_arguments():
         'x-dead-letter-exchange': 'dlx',
         'x-ttl': 6000})],
         channel.queue_declare.call_args_list)
+
+
+def test_dead_letter_exchange_should_be_declared_first():
+    q = QueueConfigurer('q')
+    dlq = QueueConfigurer(
+        'dlq',
+        arguments="""{
+            "x-dead-letter-exchange": "dlx",
+            "x-dead-letter-routing-key": "q"}""")
+    dlx = ExchangeConfigurer('dlx', 'direct')
+    ordered_deps = calculate_dependencies({
+        'q': q,
+        'dlq': dlq,
+        'dlx': dlx
+    })
+    # because dlq needs dlx, dlx should be declared before dlq
+    assert ordered_deps.index(dlx) < ordered_deps.index(dlq)


### PR DESCRIPTION
If a queue is configured with a DLX, make sure the DLX is declared as a dependency so the declaration order is correct.
