### PR TITLE
Updates the Allowed Version of Ampq

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-amqp==2.3.2
+amqp>=2.3.2,<2.5
 lockfile>=0.9.1,<0.13
 python-daemon>=2.1.2,<3.9
 configparser>=3.5,<4.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(p.join(p.dirname(__file__), 'requirements-dev.txt'), 'r') as reqs:
 
 setup(
     name='sparkplug',
-    version='1.10-dev',
+    version='1.10.0',
     author='Owen Jacobson',
     author_email='owen.jacobson@grimoire.ca',
     url='http://alchemy.grimoire.ca/python/sites/sparkplug/',

--- a/sparkplug/executor.py
+++ b/sparkplug/executor.py
@@ -2,7 +2,6 @@ import os
 import signal
 import time
 import multiprocessing
-from builtins import range
 
 
 def direct(f, *args, **kwargs):


### PR DESCRIPTION
Some of our apps use celery, which uses kombu, which now requires ampq >=2.4.0.

This relaxes the version of ampq that sparkplug uses so that we can install 2.4.0.

I ran all available tests in python 2.7 and 3.7 and they pass.

This change has also been tested in one of our apps that has a webapp, queue consumer, and celery worker, all with updated versions of sparkplug (1.10.0) and ampq (2.4.1) and it all works fine.