### PR TITLE
Lift the AMQP version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-amqp>=2.3.2,<2.5
+amqp>=2.3.2
 lockfile>=0.9.1,<0.13
 python-daemon>=2.1.2,<3.9
 configparser>=3.5,<4.0


### PR DESCRIPTION
The new version of AMQP 2.5.0 drops support for Python 3.4

Refs THUGS-1859