### PR TITLE
Replace deprecated clock with process_time

### DIFF
--- a/sparkplug/config/connection.py
+++ b/sparkplug/config/connection.py
@@ -110,7 +110,7 @@ class MultiThreadedConnection(object):
 
 def jitter():
     "returns a quasi-random floating point value between 0 and 1"
-    return (time.process_time() * (879190747.0 ** 0.5)) % 1  # kronecker sequence
+    return (time.process_time() * (879190747.0 ** 0.5)) % 1  # uses the kronecker sequence to guarantee that values are spread out instead of potentially close together
 
 
 class AMQPConnector(object):

--- a/sparkplug/config/connection.py
+++ b/sparkplug/config/connection.py
@@ -110,7 +110,8 @@ class MultiThreadedConnection(object):
 
 def jitter():
     "returns a quasi-random floating point value between 0 and 1"
-    return (time.process_time() * (879190747.0 ** 0.5)) % 1  # uses the kronecker sequence to guarantee that values are spread out instead of potentially close together
+    # uses the kronecker sequence to guarantee that values are spread out instead of potentially close together
+    return (time.process_time() * (879190747.0 ** 0.5)) % 1
 
 
 class AMQPConnector(object):

--- a/sparkplug/config/connection.py
+++ b/sparkplug/config/connection.py
@@ -110,7 +110,7 @@ class MultiThreadedConnection(object):
 
 def jitter():
     "returns a quasi-random floating point value between 0 and 1"
-    return (time.clock() * (879190747.0 ** 0.5)) % 1  # kronecker sequence
+    return (time.process_time() * (879190747.0 ** 0.5)) % 1  # kronecker sequence
 
 
 class AMQPConnector(object):


### PR DESCRIPTION
In python 3.8 time.clock was deprecated and replaced with 2 functions: https://stackoverflow.com/a/85533/1190336

I'm updating it to use the replacement method that provides the same functionality as what would be expected on a unix system.