### PR TITLE
Bump version number because of bug fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.14.2
+current_version = 1.14.3
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(p.join(p.dirname(__file__), 'README.md'), 'r') as f:
 
 setup(
     name='sparkplug',
-    version='1.14.2',
+    version='1.14.3',
     maintainer='FreshBooks',
     maintainer_email='dev@freshbooks.com',
     url='https://github.com/freshbooks/sparkplug/',


### PR DESCRIPTION
Bumping the version number to ship the fix for: https://github.com/freshbooks/sparkplug/pull/34
