### PR TITLE
Fix typo

### DIFF
--- a/sparkplug/cli.py
+++ b/sparkplug/cli.py
@@ -4,7 +4,7 @@ try:
     from configparser import ConfigParser
 except ImportError:
     # patch support for python 2.7
-    import configparter.SafeConfigParser as ConfigParser
+    import configparser.SafeConfigParser as ConfigParser
     ConfigParser.read_file = ConfigParser.readfp
 
 import optparse

--- a/sparkplug/cli.py
+++ b/sparkplug/cli.py
@@ -10,7 +10,6 @@ except ImportError:
 import optparse
 import logging
 import logging.config
-import os
 import sys
 import sparkplug.options
 import sparkplug.config


### PR DESCRIPTION
Fixing a typo and removing an unneeded import. It looks like that patch for python 2.7 probably never would have worked. Maybe we should consider removing it?