### PR TITLE
Tag metrics based on msg producer

### DIFF
--- a/example.ini
+++ b/example.ini
@@ -42,7 +42,13 @@ use = sparkplug#echo
 # Queue to consume against
 queue = events
 # Other parameters will be passed passed to the entry point
-format = %%(body)s
+format = body={body} headers={application_headers}
+time_reporters = logger
+
+[time_reporter:logger]
+use = sparkplug#logger
+#tags = consumer:some_script
+aggregation_count=1
 
 # Configure Python logging
 #

--- a/sparkplug/config/timer.py
+++ b/sparkplug/config/timer.py
@@ -15,7 +15,12 @@ class Timer(object):
 
     def __call__(self, msg):
         ret = None
-        
+
+        tags = []
+        if hasattr(msg, "application_headers") and ("producer_name" in msg.application_headers):
+            producer_name = msg.application_headers['producer_name']
+            tags.append("producer:{}".format(producer_name))
+
         try:
             start_time = datetime.datetime.now()
             if hasattr(msg, "application_headers") and ("timestamp_in_ms" in msg.application_headers):
@@ -23,7 +28,7 @@ class Timer(object):
                 wait_time = start_time - began_at
                 try:
                     for t in self._timers:
-                        t.append_wait(wait_time)
+                        t.append_wait(wait_time, tags=tags)
                 except:
                     _log.error(traceback.format_exc())
 
@@ -33,7 +38,7 @@ class Timer(object):
             try:
                 erro_time = datetime.datetime.now() - start_time
                 for t in self._timers:
-                    t.append_erro(erro_time)
+                    t.append_erro(erro_time, tags=tags)
             except:
                 _log.error(traceback.format_exc())
 
@@ -43,7 +48,7 @@ class Timer(object):
             try:
                 exec_time = datetime.datetime.now() - start_time
                 for t in self._timers:
-                    t.append_exec(exec_time)
+                    t.append_exec(exec_time, tags=tags)
             except:
                 _log.error(traceback.format_exc())
 

--- a/sparkplug/config/timereporter.py
+++ b/sparkplug/config/timereporter.py
@@ -34,10 +34,9 @@ def parse_use(group, use, load_entry_point=pkg_resources.load_entry_point):
 
 
 class TimeReporterConfigurer(DependencyConfigurer):
-    def __init__(self, name, use, aggregation_count, **kwargs):
+    def __init__(self, name, use, **kwargs):
         DependencyConfigurer.__init__(self)
         self.entry_point = parse_use('sparkplug.time_reporters', use)
-        self.aggregation_count = max(int(aggregation_count),1)
         self.name = name
         self.kwargs = kwargs
 
@@ -45,7 +44,7 @@ class TimeReporterConfigurer(DependencyConfigurer):
         # instance the plugin and add it to the global registry:
         try:
             _log.debug("Creating time_reporter from %r", self.entry_point)
-            registry[self.name] = self.entry_point(self.aggregation_count, **(self.kwargs))
+            registry[self.name] = self.entry_point(**(self.kwargs))
         except:
             _log.error("Failure to start time_reporter %r", self.entry_point)
             _log.error(traceback.format_exc())
@@ -55,4 +54,4 @@ class TimeReporterConfigurer(DependencyConfigurer):
            del registry[self.name]
 
     def __repr__(self):
-        return "TimeReporter(name={}, aggregation_count={})".format(self.name, self.aggregation_count)
+        return "TimeReporter(name={})".format(self.name)

--- a/sparkplug/examples.py
+++ b/sparkplug/examples.py
@@ -8,7 +8,7 @@ class EchoConsumer(object):
         self.format = format
 
     def __call__(self, msg):
-        text = self.format.format(body=msg.body, pid=os.getpid())
+        text = self.format.format(body=msg.body, pid=os.getpid(), application_headers=msg.application_headers)
         print(text)
         self.channel.basic_ack(msg.delivery_tag)
 

--- a/sparkplug/test/test_config/test_timereporter.py
+++ b/sparkplug/test/test_config/test_timereporter.py
@@ -1,22 +1,74 @@
-from sparkplug.timereporters.base import min_median_max
+
 from datetime import timedelta
 
-def test_timereporer_min():
-    testdata = [timedelta(seconds=x) for x in (5,3,1,6,8,9,5,3)]
-    mn, md, mx = min_median_max(testdata)
-    assert timedelta(seconds=1).total_seconds() * 1000 == mn
+try:
+    from unittest import mock
+except ImportError:
+    # because python2
+    import mock
 
-def test_timereporer_median_even_count():
-    testdata = [timedelta(hours=x) for x in (6,1,7,0,4,2,9,7)]
-    mn, md, mx = min_median_max(testdata)
-    assert timedelta(hours=5).total_seconds() * 1000 == md
 
-def test_timereporer_median_odd_count():
-    testdata = [timedelta(minutes=x) for x in (6,2,7,0,5)]
-    mn, md, mx = min_median_max(testdata)
-    assert timedelta(minutes=5).total_seconds() * 1000 == md
+def ms(millis):
+    return timedelta(milliseconds=millis)
 
-def test_timereporer_max():
-    testdata = [timedelta(seconds=x) for x in (1,8,3,9,4,2,8)]
-    mn, md, mx = min_median_max(testdata)
-    assert timedelta(seconds=9).total_seconds() * 1000 == mx
+
+@mock.patch('sparkplug.timereporters.statsd.statsdecor')
+def test_shakedown(statsdecor):
+    statsd = statsdecor._create_client()
+
+    from sparkplug.timereporters.statsd import Statsd
+
+    s = Statsd(tags='version:1')
+    s.append_exec(ms(123), tags=['hello:yes'])
+    statsd.timing.assert_called_once_with('msg.exec', 123, tags=['version:1', 'hello:yes'], rate=None)
+    statsd.timing.reset_mock()
+
+    s.append_wait(ms(124), tags=['hello:yes2'])
+    statsd.timing.assert_called_once_with('msg.wait', 124, tags=['version:1', 'hello:yes2'], rate=None)
+    statsd.timing.reset_mock()
+
+    s.append_erro(ms(125), tags=['hello:yes3'])
+    statsd.timing.assert_called_once_with('msg.erro', 125, tags=['version:1', 'hello:yes3'])
+    statsd.timing.reset_mock()
+
+    s = Statsd(tags='version:2', default_sample_rate=0.1)
+    s.append_wait(ms(126), tags=['hello:yes4'])
+    statsd.timing.assert_called_once_with('msg.wait', 126, tags=['version:2', 'hello:yes4'], rate=0.1)
+    statsd.timing.reset_mock()
+
+    s = Statsd(tags='version:2', default_sample_rate=0.1)
+    s.append_erro(ms(126), tags=['hello:yes4'])
+    statsd.timing.assert_called_once_with('msg.erro', 126, tags=['version:2', 'hello:yes4'])
+    statsd.timing.reset_mock()
+
+
+@mock.patch('sparkplug.timereporters.statsd.statsdecor')
+def test_null(statsdecor):
+    statsd = statsdecor._create_client()
+
+    from sparkplug.timereporters.statsd import Statsd
+
+    s = Statsd()
+    s.append_exec(ms(123))
+    statsd.timing.assert_called_once_with('msg.exec', 123, tags=[], rate=None)
+    statsd.timing.reset_mock()
+
+    s.append_wait(ms(124))
+    statsd.timing.assert_called_once_with('msg.wait', 124, tags=[], rate=None)
+    statsd.timing.reset_mock()
+
+    s.append_erro(ms(125))
+    statsd.timing.assert_called_once_with('msg.erro', 125, tags=[])
+    statsd.timing.reset_mock()
+
+
+@mock.patch('sparkplug.timereporters.statsd.statsdecor', new=None)
+def test_no_statsdecor():
+    from sparkplug.timereporters.statsd import Statsd
+    from sparkplug.timereporters.statsd import statsdecor
+    assert statsdecor is None
+
+    s = Statsd()
+    s.append_exec(ms(123), tags=['doesnt:matter'])
+    s.append_wait(ms(124), tags=['doesnt:matter'])
+    s.append_erro(ms(125), tags=['doesnt:matter'])

--- a/sparkplug/timereporters/base.py
+++ b/sparkplug/timereporters/base.py
@@ -1,43 +1,19 @@
 import datetime
 
-##################################################
 
 def _milliseconds(timedelta):
     return timedelta.total_seconds() * 1000
 
 
-##################################################
-
-def min_median_max(x):
-    "calculate min median max from a list of timedeltas, returns the time in milliseconds"
-    mn = 0
-    median = 0
-    mx = 0
-    if x :
-        lenx = len(x)
-        ordered = sorted(x)
-        mn = _milliseconds(ordered[0])
-        mx = _milliseconds(ordered[-1])
-        if 1 == lenx % 2 :
-            # odd number of samples
-            median = _milliseconds(ordered[lenx // 2])
-        else:
-            # even number of samples
-            median = 0.5 * _milliseconds(ordered[lenx // 2] + ordered[(lenx // 2) - 1])
-    return (mn, median, mx)
-
-
-##################################################
-
 class Base(object):
-    def __init__(self, aggregation_count):
-        self.aggregation_count = aggregation_count
-
-    def append_wait(self, delta):
+    def __init__(self):
         pass
 
-    def append_exec(self, delta):
+    def append_wait(self, delta, tags=None):
         pass
 
-    def append_erro(self, delta):
+    def append_exec(self, delta, tags=None):
+        pass
+
+    def append_erro(self, delta, tags=None):
         pass

--- a/sparkplug/timereporters/logger.py
+++ b/sparkplug/timereporters/logger.py
@@ -4,37 +4,24 @@ Sends timing information to the logs
 
 import logging
 from sparkplug.logutils import LazyLogger
-from sparkplug.timereporters.base import Base, min_median_max
+from sparkplug.timereporters.base import Base, _milliseconds
+
 
 _log = LazyLogger(__name__)
 
+
 class Logger(Base):
-    def __init__(self, aggregation_count, level="DEBUG"):
-        super(Logger, self).__init__(aggregation_count)
-        self._exec_times = []
-        self._erro_times = []
-        self._wait_times = []
+    def __init__(self, level="DEBUG"):
+        super(Logger, self).__init__()
         # get the exact method for the correct logging level:
         self.logger = getattr(_log, str(level).lower())
         assert(callable(self.logger), "Logging level on timereporters.Logger does not resolve to anything useful")
 
-    def append_exec(self, delta):
-        self._exec_times.append(delta)
-        if len(self._exec_times) >= self.aggregation_count :
-            mn, md, mx = min_median_max(self._exec_times)
-            del self._exec_times[:]
-            self.logger("msg exec (min med max) ms: {:0.2f} {:0.2f} {:0.2f}".format(mn, md, mx))
+    def append_exec(self, delta, tags=None):
+        self.logger("OK: time {}, tags {}".format(delta, tags))
 
-    def append_erro(self, delta):
-        self._erro_times.append(delta)
-        if len(self._erro_times) >= self.aggregation_count :
-            mn, md, mx = min_median_max(self._erro_times)
-            del self._erro_times[:]
-            self.logger("msg erro (min med max) ms: {:0.2f} {:0.2f} {:0.2f}".format(mn, md, mx))
+    def append_erro(self, delta, tags=None):
+        self.logger("ERROR: time {}, tags {}".format(delta, tags))
 
-    def append_wait(self, delta):
-        self._wait_times.append(delta)
-        if len(self._wait_times) >= self.aggregation_count :
-            mn, md, mx = min_median_max(self._wait_times)
-            del self._wait_times[:]
-            self.logger("msg wait (min med max) ms: {:0.2f} {:0.2f} {:0.2f}".format(mn, md, mx))
+    def append_wait(self, delta, tags=None):
+        self.logger("WAIT TIME: time {}, tags {}".format(delta, tags))

--- a/sparkplug/timereporters/statsd.py
+++ b/sparkplug/timereporters/statsd.py
@@ -4,15 +4,14 @@ Sends timing information to Datadog custom metrics
     [time_reporter:statsdtimer]
     # which class to instance?
     use = sparkplug#statsd
-    # How many samples to combine during each reporting period,
-    # since Datadog aggregates the data itself, we don't need to.
-    aggregation_count = 1
     # Tags to help with reporting:
     tags = service:myconsumer
     # Any extra parameters will be passed to statsdecor
     port = 8125
     host = localhost
     vendor = datadog
+    # set to lower (eg. 0.1 or 0.01) if the load is too much
+    default_sample_rate = 1
 
     [consumer:myconsumer]
     <blah>
@@ -20,8 +19,6 @@ Sends timing information to Datadog custom metrics
     time_reporters = statsdtimer
 
 Parameters:
-    aggregation_count : integer, required, same as base class:
-      number of samples to combine before reporting
     tags : list or None, optional, the list of key:value tags to associate
       with the sample sent to datadog
     extra parameters will be sent to the underlying statsdecor module, e.g.:
@@ -32,61 +29,78 @@ Parameters:
 """
 
 from sparkplug.logutils import LazyLogger
+from sparkplug.timereporters.base import Base
+
+
 _log = LazyLogger(__name__)
 
-from sparkplug.timereporters.base import Base, min_median_max
 
 try:
     # pip install statsdecor
     import statsdecor
-
-    class Statsd(Base):
-        def __init__(self, aggregation_count, tags=None, **kwargs):
-            super(Statsd, self).__init__(aggregation_count)
-
-            self.exec = []
-            self.erro = []
-            self.wait = []
-
-            conf = {"prefix": "sparkplug"}
-            conf.update(kwargs)
-            # Don't share the global client, we might be
-            # configured differently than the global:
-            self.statsd = statsdecor._create_client(**conf)
-
-            self.tags = self._parse_tags(tags)
-
-        def _parse_tags(self, tags):
-            ret = None
-            if tags:
-                ret = [x.strip() for x in tags.split(',')]
-            return ret
-
-        def append_exec(self, delta):
-            self.exec.append(delta)
-            if len(self.exec) >= self.aggregation_count:
-                mn, md, mx = min_median_max(self.exec)
-                del self.exec[:]
-                self.statsd.timing('msg.exec', md, tags=self.tags)
-
-        def append_erro(self, delta):
-            self.erro.append(delta)
-            if len(self.erro) >= self.aggregation_count:
-                mn, md, mx = min_median_max(self.erro)
-                del self.erro[:]
-                self.statsd.timing('msg.erro', md, tags=self.tags)
-
-        def append_wait(self, delta):
-            self.wait.append(delta)
-            if len(self.wait) >= self.aggregation_count:
-                mn, md, mx = min_median_max(self.wait)
-                del self.wait[:]
-                self.statsd.timing('msg.wait', md, tags=self.tags)
-
-
 except ImportError:
+    statsdecor = None
 
-    class Statsd(Base):
-        def __init__(self, aggregation_count, tags=None, **kwargs):
-            super(Statsd, self).__init__(aggregation_count)
-            _log.warning('Statsd time_reporter unavailable, using noop. (Do you need to "pip install statsdecor"?)')
+
+_log = LazyLogger(__name__)
+
+
+class _Statsd(Base):
+
+    def __init__(self, tags=None, **kwargs):
+        super(_Statsd, self).__init__()
+
+        # we can't rely on statsdecor to pass on the default sample rate. So we're doing it ourselves.
+        if 'default_sample_rate' in kwargs:
+            self.sample_rate = float(kwargs.pop('default_sample_rate'))
+        else:
+            # None doesn't float.
+            self.sample_rate = None
+
+        conf = {"prefix": "sparkplug"}
+        conf.update(kwargs)
+        # Don't share the global client, we might be
+        # configured differently than the global:
+        self.statsd = statsdecor._create_client(**conf)
+
+        self.tags = self._parse_tags(tags)
+
+    def _parse_tags(self, tags):
+        ret = []
+        if tags:
+            ret = [x.strip() for x in tags.split(',')]
+        return ret
+
+    def append_exec(self, delta, tags=None):
+        # This could be more interesting as a distribution.
+        tags = self.tags + (tags or [])
+        ms = delta.total_seconds()*1000
+        self.statsd.timing('msg.exec', ms, tags=tags, rate=self.sample_rate)
+
+    def append_erro(self, delta, tags=None):
+        tags = self.tags + (tags or [])
+        # deliberately leaving the sample rate off--if these are rare we want to see them.
+        ms = delta.total_seconds()*1000
+        self.statsd.timing('msg.erro', ms, tags=tags)
+
+    def append_wait(self, delta, tags=None):
+        # use "timing" instead of "distribution" because the data is pretty
+        # monotonic: if there's a sudden backlog of messages in a FIFO queue,
+        # then the timings should be roughly the same, going up a bit at a time..
+        # the meaning will be in the values, not the distribution of those values.
+        tags = self.tags + (tags or [])
+        ms = delta.total_seconds()*1000
+        self.statsd.timing('msg.wait', ms, tags=tags, rate=self.sample_rate)
+
+
+class _NoopStatsd(Base):
+    def __init__(self, tags=None, **kwargs):
+        super(_NoopStatsd, self).__init__()
+
+
+def Statsd(*args, **kwargs):
+    if statsdecor is None:
+        _log.warning('Statsd time_reporter unavailable, using noop. (Do you need to "pip install statsdecor"?)')
+        return _NoopStatsd(*args, **kwargs)
+    else:
+        return _Statsd(*args, **kwargs)


### PR DESCRIPTION
This will allow us to track message volume and time-in-queue by producers as well as consumers.

If messages include `producer_name` in the message headers, then
metrics are tagged with producer:${producer_name}.

Also removed some premature optimization of those stats collectors.
Explicitly let Datadog handle it with sample rates.

Refs INFRA-587