### PR TITLE
ref NEODXP-869; fix private artifactory repository access, fix flake issue with automerge action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ registries:
 
 updates:
 - package-ecosystem: pip
+  insecure-external-code-execution: allow
   directory: "/"
   schedule:
     interval: daily


### PR DESCRIPTION
refs:
* [fix private artifactory repository access](https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#insecure-external-code-execution)
* [fix flake issue with automerge action](https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/60#issuecomment-806170152)