### PR TITLE
Handle INT/TERM signal and set a flag to terminate

### DIFF
--- a/sparkplug/__init__.py
+++ b/sparkplug/__init__.py
@@ -1,0 +1,11 @@
+from sparkplug.logutils import LazyLogger
+_log = LazyLogger(__name__)
+
+
+class SignalHandler:
+    should_terminate = False
+
+    @classmethod
+    def signal_handler(cls, sig, frame):
+        _log.warning("Signal %s received, setting `should_terminate` flag", sig)
+        SignalHandler.should_terminate = True

--- a/sparkplug/cli.py
+++ b/sparkplug/cli.py
@@ -1,4 +1,7 @@
 from __future__ import with_statement
+import signal
+
+from sparkplug import SignalHandler
 
 try:
     from configparser import ConfigParser
@@ -85,6 +88,9 @@ def run_sparkplug(
         options.connector,
         options.connection
     )
+
+    signal.signal(signal.SIGINT, SignalHandler.signal_handler)
+    signal.signal(signal.SIGTERM, SignalHandler.signal_handler)
 
     try:
         _log.info("Starting sparkplug.")

--- a/sparkplug/config/connection.py
+++ b/sparkplug/config/connection.py
@@ -46,6 +46,7 @@ import time
 import socket
 import threading
 
+from sparkplug import SignalHandler
 from sparkplug.config.types import convert, parse_bool
 from sparkplug.logutils import LazyLogger
 from amqp import spec
@@ -140,6 +141,9 @@ class AMQPConnector(object):
     def pump(self, connection, channel):
         timeout = connection.heartbeat * 0.4 or None
         while True:
+            if SignalHandler.should_terminate:
+                _log.warning("Terminating Gracefully")
+                raise SystemExit
             _log.debug("Waiting for a message.")
             try:
                 channel.wait(spec.Basic.Deliver, timeout=timeout)

--- a/sparkplug/config/consumer.py
+++ b/sparkplug/config/consumer.py
@@ -51,6 +51,7 @@ To register entry points in your own egg files, use ``setuptools``'
 A complete example is included in the sparkplug source.
 """
 
+from sparkplug import SignalHandler
 from multiprocessing.pool import ThreadPool
 from multiprocessing import TimeoutError
 import traceback
@@ -87,6 +88,9 @@ class HeartbeatConsumer(object):
         self._heartbeater = Heartbeater(connection)
 
     def __call__(self, msg):
+        if SignalHandler.should_terminate:
+            _log.warning("Terminating Gracefully")
+            raise SystemExit
         result = None
         try:
             with self._heartbeater:


### PR DESCRIPTION
As we run this in Kubernetes we do not want to terminate immediately on TERM, nor do we want to ignore the TERM and continue on. We want to set a flag for termination and make sure any in-flight message may continue processing until completion. Before a new message starts processing, we will raise SystemExit. If no message starts processing in that time frame, SIGKILL will eventually be sent.

Bumping versions is still manual and must be done afterwards.