### PR TITLE
Check for termination file before starting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0rc1
+current_version = 1.23.0rc2
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(p.join(p.dirname(__file__), 'README.md'), 'r') as f:
 
 setup(
     name='sparkplug',
-    version='1.23.0rc1',
+    version='1.23.0rc2',
     maintainer='FreshBooks',
     maintainer_email='dev@freshbooks.com',
     url='https://github.com/freshbooks/sparkplug/',

--- a/sparkplug/cli.py
+++ b/sparkplug/cli.py
@@ -92,6 +92,9 @@ def run_sparkplug(
     signal.signal(signal.SIGINT, SignalHandler.signal_handler)
     signal.signal(signal.SIGTERM, SignalHandler.signal_handler)
 
+    with open("/tmp/sparkplug_ready", "a"):
+        pass
+
     try:
         _log.info("Starting sparkplug.")
         connector.run()


### PR DESCRIPTION
A workaround to be sure, but I've written worse code.

This adds a file `/tmp/sparkplug_ready` after sparkplug has registered
its signal handlers. This gives workloads running in kubernetes the
ability to check for this file before sending a signal to terminate.

While https://github.com/freshbooks/sparkplug/pull/42 did add a signal
handler to make sure sparkplug exits _after_ processing a message,
there are extremely rare situations where kubernetes sends a TERM
signal before sparkplug registers it's signal handler. In these situations,
the TERM is swallowed up and eventually a KILL is executed at an
arbitrary time, causing issues.