### PR TITLE
Update configparser version constraint in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 amqp>=2.3.2
 lockfile>=0.9.1,<0.13
-configparser>=3.5,<6.0
+configparser>=3.5,<8.0


### PR DESCRIPTION
https://2ndsiteinc.atlassian.net/browse/SHALP-6783
as part of the above SHALP we need to update `configparser` to 7.2.0 but sparkplug was blocking it.